### PR TITLE
Fixes #5 doesnt work with browserify 13.0.1

### DIFF
--- a/transform.js
+++ b/transform.js
@@ -11,7 +11,7 @@ var path      = require('path')
 module.exports = fresh
 
 var parent = (
-    '( arguments.length === 3'
+    '( arguments.length === 7'
   + '? arguments.callee.caller'
   + ': arguments.callee.caller.caller'
   + ')'


### PR DESCRIPTION
In browserify v13.0.1 the call contains this + 7 additional arguments. However the ternery operator selects for 3 arguments : 

```
(function e(t, n, r) {
    function s(o, u) {
        if (!n[o]) {
            if (!t[o]) {
                var a = typeof require == "function" && require;
                if (!u && a) return a(o, !0);
                if (i) return i(o, !0);
                var f = new Error("Cannot find module '" + o + "'");
                throw f.code = "MODULE_NOT_FOUND", f
            }
            var l = n[o] = {
                exports: {}
            };
            t[o][0].call(l.exports, function(e) {
                var n = t[o][1][e];
                return s(n ? n : e)
            }, l, l.exports, e, t, n, r)     // <---------------------------------HERE
        }
        return n[o].exports
    }
```

Note that we need to get the key for the t[] map, which is the integer 'o' passed to the call to s(o,u). This is arguments.callee.caller in the call to the following function :
```
    1: [function(require, module, exports) {
        var $0 = arguments.length === 7 ? arguments.callee.caller : arguments.callee.caller.caller,
            $1 = (arguments.length === 7 ? arguments.callee.caller : arguments.callee.caller.caller).arguments[0];
        var fresh = require('fresh-require');
        CTX = function(name) {
            this.name = name;
            this.OBJ1 = fresh('./obj1.js', $0, $1) || require('./obj1.js');
            this.OBJ1.ctx = this;
            this.OBJ2 = fresh('./obj2.js', $0, $1) || require('./obj2.js');
            this.OBJ2.ctx = this;
        };
        module.exports = CTX;
    }, 
```
